### PR TITLE
feat: session id 테스트를 위한 api 추가

### DIFF
--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/TestApi.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/TestApi.kt
@@ -1,0 +1,21 @@
+package dev.jxmen.cs.ai.interviewer
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class TestApi {
+    @GetMapping("/api/test/session-id")
+    fun testSessionId(httpServletRequest: HttpServletRequest): ResponseEntity<TestSessionIdResponse> {
+        val sessionId = httpServletRequest.session.id
+        val res = TestSessionIdResponse(sessionId = sessionId)
+
+        return ResponseEntity.ok(res)
+    }
+}
+
+data class TestSessionIdResponse(
+    val sessionId: String,
+)


### PR DESCRIPTION
GET `/api/test/session-id` 요청 시 sessionId를 응답한다.