### PR TITLE
fix: chat.score nullable로 설정

### DIFF
--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chat.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chat.kt
@@ -33,7 +33,7 @@ class Chat(
     @Comment("채팅 내용")
     val message: String,
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     @Comment("점수")
     val score: Int? = null,
 

--- a/src/main/resources/db/migration/V5__fix_to_chat_score_nullable.sql
+++ b/src/main/resources/db/migration/V5__fix_to_chat_score_nullable.sql
@@ -1,0 +1,2 @@
+alter table chat
+    alter column score set not null;


### PR DESCRIPTION
Answer만 해당 값이 들어가므로 잘못된 설정을 제거한다
