### PR TITLE
fix: 불필요한 chat score not null sql 제거

### DIFF
--- a/src/main/resources/db/migration/V5__fix_to_chat_score_nullable.sql
+++ b/src/main/resources/db/migration/V5__fix_to_chat_score_nullable.sql
@@ -1,2 +1,0 @@
-alter table chat
-    alter column score set not null;


### PR DESCRIPTION
sql 또한 문법 오류가 있고, JPA Entity를 수정하는 커밋에서 실수로 같이
추가하여 다시 제거함
