### PR TITLE
fix: 채팅 내역이 없을 경우 question 추가 로직 삭제

### DIFF
--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/service/adapter/ChatService.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/service/adapter/ChatService.kt
@@ -19,12 +19,7 @@ class ChatService(
         answer: String,
         nextQuestion: String,
         score: Int,
-        chats: List<Chat>,
     ) {
-        if (chats.isEmpty()) {
-            addQuestion(subject, userSessionId)
-        }
-
         addAnswer(subject, userSessionId, answer, score)
         addNextQuestion(subject, userSessionId, nextQuestion)
     }
@@ -42,21 +37,6 @@ class ChatService(
                 message = answer,
                 chatType = ChatType.ANSWER,
                 score = score,
-            )
-
-        chatCommandRepository.save(chat)
-    }
-
-    private fun addQuestion(
-        subject: Subject,
-        userSessionId: String,
-    ) {
-        val chat =
-            Chat(
-                subject = subject,
-                userSessionId = userSessionId,
-                message = subject.question,
-                chatType = ChatType.QUESTION,
             )
 
         chatCommandRepository.save(chat)

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/service/port/ChatUseCase.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/service/port/ChatUseCase.kt
@@ -1,6 +1,5 @@
 package dev.jxmen.cs.ai.interviewer.domain.chat.service.port
 
-import dev.jxmen.cs.ai.interviewer.domain.chat.Chat
 import dev.jxmen.cs.ai.interviewer.domain.subject.Subject
 
 interface ChatUseCase {
@@ -10,6 +9,5 @@ interface ChatUseCase {
         answer: String,
         nextQuestion: String,
         score: Int,
-        chats: List<Chat>,
     )
 }

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/subject/service/adapter/SubjectService.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/subject/service/adapter/SubjectService.kt
@@ -36,7 +36,6 @@ class SubjectService(
             answer = command.answer,
             nextQuestion = apiResponse.nextQuestion,
             score = apiResponse.score,
-            chats = chats,
         )
 
         return SubjectAnswerResponse(


### PR DESCRIPTION
ai에게 권한 부여/ai가 해당 권한 부여에 대한 답변은 기존 채팅 목록이 없다면 Claude에서 생성하기 때문에 처음 답변부터 저장하도록 수정한다.
