### PR TITLE
fix: 허용되지 않은 메서드 호출 시 405 응답

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "dev.jxmen"
-version = "1.3.2"
+version = "1.3.3"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/common/config/security/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/common/config/security/JwtAuthenticationFilter.kt
@@ -13,6 +13,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 import org.springframework.stereotype.Component
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.filter.OncePerRequestFilter
 import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.HandlerMapping
@@ -112,7 +113,13 @@ class JwtAuthenticationFilter(
 
     private fun requireLogin(request: HttpServletRequest): Boolean {
         for (handlerMapping in handlerMappings) {
-            val handler = handlerMapping.getHandler(request) ?: continue
+            val handler =
+                try {
+                    handlerMapping.getHandler(request) ?: continue
+                } catch (e: HttpRequestMethodNotSupportedException) {
+                    return false
+                }
+
             if (handler.handler is HandlerMethod) {
                 val handlerMethod = handler.handler as HandlerMethod
                 if (handlerMethod.getMethodAnnotation(RequireLoginApi::class.java) != null) {

--- a/src/test/kotlin/dev/jxmen/cs/ai/interviewer/CsAiInterviewerApplicationTests.kt
+++ b/src/test/kotlin/dev/jxmen/cs/ai/interviewer/CsAiInterviewerApplicationTests.kt
@@ -1,13 +1,76 @@
 package dev.jxmen.cs.ai.interviewer
 
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.TestPropertySource
+import org.springframework.http.HttpMethod
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MockMvcResultMatchersDsl
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
 
 @SpringBootTest
-@TestPropertySource(properties = ["CLAUDE_API_KEY=test"])
-class CsAiInterviewerApplicationTests {
-    @Test
-    fun contextLoads() {
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class CsAiInterviewerApplicationTests(
+    private val context: WebApplicationContext,
+) : DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    private lateinit var mockMvc: MockMvc
+
+    init {
+        beforeEach {
+            mockMvc = MockMvcBuilders.webAppContextSetup(context).build()
+        }
+
+        describe("CsAiInterviewerApplicationTests") {
+            it("context loads") {
+                // contextLoads test logic
+            }
+
+            it("승인되지 않은 사용자 로그인 요청에 대해 401로 응답해야 합니다.") {
+                listOf(
+                    Pair(HttpMethod.GET, "/api/v1/subjects/1/chats"),
+                    Pair(HttpMethod.GET, "/api/v1/subjects/my"),
+                    Pair(HttpMethod.GET, "/api/v5/subjects/1/answer"),
+                    Pair(HttpMethod.POST, "/api/v2/subjects/1/chats/archive"),
+                ).forEach {
+                    when (it.first) {
+                        HttpMethod.GET -> mockMvc.get(it.second).andExpect { expectRequireLogin() }
+                        HttpMethod.POST -> mockMvc.post(it.second).andExpect { expectRequireLogin() }
+                        else -> throw IllegalArgumentException("Unsupported method: ${it.first}")
+                    }
+                }
+            }
+
+            val getMethodApis =
+                listOf(
+                    "/api/version",
+                    "/api/v1/subjects",
+                    "/api/v1/subjects/1",
+                    "/api/v1/subjects/1/chats",
+                    "/api/v1/subjects/my",
+                    "/api/v5/subjects/1/answer",
+                )
+            getMethodApis.forEach { url ->
+                it("지원되지 않는 메서드 호출에 대해 405로 응답해야 합니다. - $url") {
+                    mockMvc
+                        .post(url)
+                        .andExpect {
+                            status { isMethodNotAllowed() }
+                        }
+                }
+            }
+        }
+    }
+
+    private fun MockMvcResultMatchersDsl.expectRequireLogin() {
+        status { isUnauthorized() }
+        jsonPath("$.success") { value(false) }
+        jsonPath("$.error.code") { value("REQUIRE_LOGIN") }
+        jsonPath("$.error.status") { value(401) }
     }
 }

--- a/src/test/kotlin/dev/jxmen/cs/ai/interviewer/MemberScenarioTest.kt
+++ b/src/test/kotlin/dev/jxmen/cs/ai/interviewer/MemberScenarioTest.kt
@@ -23,17 +23,14 @@ import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.model.Generation
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.http.HttpMethod
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
-import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.MockMvcResultMatchersDsl
 import org.springframework.test.web.servlet.client.MockMvcWebTestClient
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -69,23 +66,6 @@ class MemberScenarioTest(
          * WebTestClient는 WebFlux를 사용하는 경우에 사용. mockMvc는 MockMvcWebTestClient를 사용
          */
         webTestClient = MockMvcWebTestClient.bindToApplicationContext(context).build()
-    }
-
-    @Test
-    @WithAnonymousUser
-    fun `인증되지 않은 유저가 인증이 필요한 로그인 요청 시 401을 응답한다`() {
-        listOf(
-            Pair(HttpMethod.GET, "/api/v1/subjects/1/chats"),
-            Pair(HttpMethod.GET, "/api/v1/subjects/my"),
-            Pair(HttpMethod.GET, "/api/v5/subjects/1/answer"),
-            Pair(HttpMethod.POST, "/api/v2/subjects/1/chats/archive"),
-        ).forEach {
-            when (it.first) {
-                HttpMethod.GET -> mockMvc.get(it.second).andExpect { expectRequireLogin() }
-                HttpMethod.POST -> mockMvc.post(it.second).andExpect { expectRequireLogin() }
-                else -> throw IllegalArgumentException("Unsupported method: ${it.first}")
-            }
-        }
     }
 
     @Test
@@ -267,13 +247,6 @@ class MemberScenarioTest(
 
         val archiveContents = chatArchiveContentQueryRepository.findByArchive(archives[0])
         archiveContents.size shouldBe 3
-    }
-
-    private fun MockMvcResultMatchersDsl.expectRequireLogin() {
-        status { isUnauthorized() }
-        jsonPath("$.success") { value(false) }
-        jsonPath("$.error.code") { value("REQUIRE_LOGIN") }
-        jsonPath("$.error.status") { value(401) }
     }
 
     private fun createOAuth2AuthenticationToken(

--- a/src/test/kotlin/dev/jxmen/cs/ai/interviewer/presentation/VersionApiTest.kt
+++ b/src/test/kotlin/dev/jxmen/cs/ai/interviewer/presentation/VersionApiTest.kt
@@ -11,7 +11,6 @@ import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.test.context.TestConstructor
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
@@ -19,7 +18,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 
 @SpringBootTest
-@TestPropertySource(properties = ["CLAUDE_API_KEY=test"])
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class VersionApiTest(
     private val context: WebApplicationContext,


### PR DESCRIPTION
JwtAuthenticationFilter에서 예외처리 추가
