### PR TITLE
채팅 누락된 다중컬럼 인덱스 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "dev.jxmen"
-version = "1.3.3"
+version = "1.3.4"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -26,6 +26,9 @@ repositories {
     maven { url = uri("https://repo.spring.io/snapshot") }
 }
 
+/**
+ * NOTE: 이 부분은 buildSrc로 분리하여 관리하는 것이 좋음
+ */
 object Versions {
     const val EPAGES = "0.17.1"
     const val MOCKK = "1.13.11"

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chat.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chat.kt
@@ -3,7 +3,6 @@ package dev.jxmen.cs.ai.interviewer.domain.chat
 import dev.jxmen.cs.ai.interviewer.domain.BaseEntity
 import dev.jxmen.cs.ai.interviewer.domain.member.Member
 import dev.jxmen.cs.ai.interviewer.domain.subject.Subject
-import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -16,7 +15,11 @@ import java.time.LocalDateTime
 
 @Suppress("ktlint:standard:no-blank-line-in-list")
 @Entity
-@Table(indexes = [Index(name = "idx_subject_userSessionId", columnList = "subject_id,userSessionId")])
+@Table(
+    indexes = [
+        Index(name = "idx_chat_subject_id_member_id", columnList = "subject_id,member_id"),
+    ],
+)
 class Chat(
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -28,10 +31,6 @@ class Chat(
     @JoinColumn(name = "member_id")
     @Comment("멤버 아이디")
     val member: Member? = null,
-
-    @Column(nullable = true)
-    @Comment("유저 세션 아이디")
-    val userSessionId: String? = null, // NOTE: 유저 도메인이 추가되면 memberId로 변경 예정
 
     @get:Embedded
     val content: ChatContent,

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/persistence/entity/chat/JpaChatArchive.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/persistence/entity/chat/JpaChatArchive.kt
@@ -34,8 +34,4 @@ class JpaChatArchive(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     val member: Member,
-) : BaseEntity() {
-    constructor(id: Long, subject: Subject, member: Member) : this(subject, member) {
-        this.id = id
-    }
-}
+) : BaseEntity()

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/persistence/entity/chat/JpaChatArchive.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/persistence/entity/chat/JpaChatArchive.kt
@@ -34,4 +34,12 @@ class JpaChatArchive(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     val member: Member,
-) : BaseEntity()
+) : BaseEntity() {
+    /**
+     * NOTE: Kotlin JDSL에서 사용하기 위해 추가한 생성자
+     */
+    @Suppress("unused")
+    private constructor(id: Long, subject: Subject, member: Member) : this(subject, member) {
+        this.id = id
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,13 +75,17 @@ spring.config.activate.on-profile: dev
 spring:
   datasource:
     name: cs-ai-interviewer
-    url: jdbc:mariadb://localhost:3313/cs-ai
-    username: root
-    password: password
-    driver-class-name: org.mariadb.jdbc.Driver
+    hikari:
+      username: root
+      password: password
+      # 출처: https://techblog.woowahan.com/2695/
+      # 출처: https://velog.io/@wisepine/JPA-%EC%82%AC%EC%9A%A9-%EC%8B%9C-19%EA%B0%80%EC%A7%80-Tip
+      jdbc-url: jdbc:mariadb://localhost:3313/cs-ai?rewriteBatchedStatements=true&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=999999
+      driver-class-name: org.mariadb.jdbc.Driver
+
   session:
     jdbc:
-      initialize-schema: never
+      initialize-schema: always
   flyway:
     enabled: true
   jpa:

--- a/src/main/resources/db/migration/V8__240829_add_chat_multi_column_idx.sql
+++ b/src/main/resources/db/migration/V8__240829_add_chat_multi_column_idx.sql
@@ -1,0 +1,17 @@
+# 미사용 userSessionId 인덱스 및 컬럼 삭제
+DROP INDEX idx_subject_userSessionId ON chat;
+
+ALTER TABLE chat
+    DROP COLUMN user_session_id;
+
+# 채팅방 조회 성능을 위한 인덱스 추가
+CREATE INDEX idx_chat_subject_id_member_id ON chat (subject_id, member_id, created_at);
+
+# 기존 sessionId를 사용하던 데이터 삭제
+DELETE
+FROM chat
+WHERE member_id IS NULL;
+
+# 기존에 userSessionId 때문에 nullable 로 설정되어 있던 member_id 컬럼을 NOT NULL 로 변경
+ALTER TABLE chat
+    MODIFY COLUMN member_id BIGINT NOT NULL AFTER subject_id;

--- a/src/test/kotlin/dev/jxmen/cs/ai/interviewer/MemberScenarioTest.kt
+++ b/src/test/kotlin/dev/jxmen/cs/ai/interviewer/MemberScenarioTest.kt
@@ -115,10 +115,11 @@ class MemberScenarioTest(
                             Pair(HttpMethod.GET, "/api/v5/subjects/${subject.id}/answer"),
                         )
 
-                    apis.forEach { (method, api) ->
+                    apis.forEach { (method, url) ->
                         when (method) {
-                            HttpMethod.GET -> mockMvc.get(api).andExpect { status { isUnauthorized() } }
-                            HttpMethod.POST -> mockMvc.post(api).andExpect { status { isUnauthorized() } }
+                            HttpMethod.GET -> mockMvc.get(url).andExpect { status { isUnauthorized() } }
+                            HttpMethod.POST -> mockMvc.post(url).andExpect { status { isUnauthorized() } }
+                            else -> throw IllegalArgumentException("Unsupported method: $method")
                         }
                     }
                 }
@@ -161,7 +162,7 @@ class MemberScenarioTest(
                     answer(subject, answer)
 
                     validateChatSaved(subject, answer, nextQuestion, score)
-                    validateMySubjectHasMaxScore(10)
+                    validateMySubjectHasMaxScore(score)
                 }
 
                 it("멤버가 채팅을 초기화(아카이브)하면 채팅 내역이 지워지고, 아카이브에 저장된다") {


### PR DESCRIPTION
기존 JPQL에서 subject_id -> member_id -> createdAt 으로 조회가 많이 되므로, 해당 컬럼들로 인덱스를 설정하였다.

```kt
@Query(
    """
        SELECT c
        FROM Chat c
        WHERE c.subject = :subject
        AND c.member = :member
        ORDER BY c.createdAt ASC
        """,
)
```

실행계획 비교 결과 기존 테이블 풀 스캔(type=`all`)에서 `ref`로 변경된다.

![image](https://github.com/user-attachments/assets/3595e467-4125-4883-8b94-871ae03fe4a7)

