### PR TITLE
fix: aop 실행시간 로깅 persistence adapter로 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "dev.jxmen"
-version = "1.3.5"
+version = "1.3.6"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/common/aop/ExecutionTimeLoggingAspect.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/common/aop/ExecutionTimeLoggingAspect.kt
@@ -13,7 +13,7 @@ class ExecutionTimeLoggingAspect {
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
     @Pointcut(
-        "within(dev.jxmen.cs.ai.interviewer.application.adapter..*)",
+        "within(dev.jxmen.cs.ai.interviewer.persistence.adapter..*)",
     )
     fun adapterMethods() {
         // Pointcut - do nothing here


### PR DESCRIPTION
패키지 이동 시에 변경하지 않았던 내용 설정 (#138)
