### PR TITLE
refactor: 불필요한 member entity equals/hashcode 제거

### DIFF
--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chat.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chat.kt
@@ -27,10 +27,10 @@ class Chat(
     @Comment("주제")
     val subject: Subject,
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = true) // NOTE: sessionId 컬럼 제거 시 nullable 제거
+    @ManyToOne(fetch = FetchType.LAZY) // NOTE: sessionId 컬럼 제거 시 nullable 제거
     @JoinColumn(name = "member_id")
     @Comment("멤버 아이디")
-    val member: Member? = null,
+    val member: Member,
 
     @get:Embedded
     val content: ChatContent,

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chats.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/chat/Chats.kt
@@ -12,7 +12,7 @@ data class Chats(
     }
 
     fun validateMatchMember(member: Member) {
-        require(chats.all { it.member == member }) { "멤버가 일치하지 않습니다." }
+        require(chats.all { it.member.equalsId(member) }) { "멤버가 일치하지 않습니다." }
     }
 
     fun validateNotUseAllAnswers() {

--- a/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/member/Member.kt
+++ b/src/main/kotlin/dev/jxmen/cs/ai/interviewer/domain/member/Member.kt
@@ -12,6 +12,7 @@ import java.io.Serializable
 @Suppress("ktlint:standard:no-blank-line-in-list")
 @Entity
 @Table(
+    // TODO: 구글 외 다른 소셜 로그인을 지원한다면 email unique 제약조건을 제거할지 검토 필요
     uniqueConstraints = [UniqueConstraint(columnNames = ["email"])],
 )
 class Member(
@@ -20,6 +21,7 @@ class Member(
     @Comment("이름")
     val name: String,
 
+    // TODO: 구글 외 다른 소셜 로그인을 지원한다면 email unique 제약조건을 제거할지 검토 필요
     @Column(nullable = false, unique = true)
     @Comment("이메일")
     val email: String,
@@ -54,24 +56,5 @@ class Member(
         }
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Member
-
-        if (id != other.id) return false
-        if (name != other.name) return false
-        if (email != other.email) return false
-        if (loginType != other.loginType) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = name.hashCode()
-        result = 31 * result + email.hashCode()
-        result = 31 * result + loginType.hashCode()
-        return result
-    }
+    fun equalsId(other: Member): Boolean = id == other.id
 }

--- a/src/test/kotlin/dev/jxmen/cs/ai/interviewer/MemberScenarioTest.kt
+++ b/src/test/kotlin/dev/jxmen/cs/ai/interviewer/MemberScenarioTest.kt
@@ -61,7 +61,7 @@ class MemberScenarioTest(
     private val fixtureMonkey = FixtureMonkey.builder().plugin(KotlinPlugin()).build()
 
     @MockBean
-    lateinit var reactiveMemberChatService: ChatAnswerUseCase
+    lateinit var chatAnswerUseCase: ChatAnswerUseCase
 
     init {
         beforeEach {
@@ -137,7 +137,7 @@ class MemberScenarioTest(
                     memberCommandRepository.save(member)
                     setAuthentication(member)
 
-                    given { reactiveMemberChatService.answer(any()) }.willReturn {
+                    given { chatAnswerUseCase.answer(any()) }.willReturn {
                         Flux
                             .create<ChatResponse?> {
                                 it.next(ChatResponse(listOf(Generation(answer))))


### PR DESCRIPTION
- 멤버 일치 여부 equalsId로 대체
- 이미 적용된 chat entity null 제약조건 제거 (이미 적용됨)
