### PR TITLE
feat: prod 환경에서 max pool size 25로 조정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "dev.jxmen"
-version = "1.3.6"
+version = "1.3.7"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,7 @@ spring:
           model: claude-3-5-sonnet-20240620
           temperature: 0.7 # 분석/객관식에는 0.0에 가까운 온도를 사용하고, 창의적이고 생성적인 작업에는 1.0에 가까운 온도를 사용하세요.
 
+# TODO: Deprecated - remove after migration spring ai
 claude:
   api-key: ${CLAUDE_API_KEY}
 
@@ -108,6 +109,10 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver
+    hikari:
+      # minimum-idle은 별도로 설정하지 않으면 maximum-pool-size와 같은 값으로 설정됨(미변경 권장)
+      maximum-pool-size: 25
+
   session:
     jdbc:
       initialize-schema: never


### PR DESCRIPTION
현재 mysql 최대 커넥션은 30이다. 서버 scale-out은 고려하고 있지 않은 상황이고, 외부 접속 등도 하기 위해 25로 설정한다.