### PR TITLE
프로메테우스 의존성 및 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "dev.jxmen"
-version = "1.3.7"
+version = "1.3.8"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     // spring boot
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 
     // spring ai
     implementation("org.springframework.ai:spring-ai-anthropic-spring-boot-starter:${Versions.SPRING_AI_ANTHROPIC}")
@@ -117,6 +118,9 @@ dependencies {
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client:${Versions.MARIADB_JAVA_CLIENT}") {
         exclude(group = "com.github.waffle", module = "waffle-jna")
     }
+
+    // prometheus
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
     // MacOS에서 Netty 사용 시 Apple Silicon 지원을 위해 추가
     if (isAppleSilicon()) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,6 +99,26 @@ logging:
       hibernate:
         SQL: DEBUG
 
+# Security Actuator 안전하게 사용하기 - https://techblog.woowahan.com/9232/
+management:
+  server:
+    port: ${MANAGEMENT_SERVER_PORT}
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, info
+      base-path: ${MANAGEMENT_ENDPOINTS_WEB_BASE_PATH}
+    jmx:
+      exposure:
+        exclude: '*'
+  endpoint:
+    health:
+      enabled: true
+    info:
+      enabled: true
+    prometheus:
+      enabled: true
+
 ---
 spring.config.activate.on-profile: prod
 
@@ -121,3 +141,23 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
+
+# Security Actuator 안전하게 사용하기 - https://techblog.woowahan.com/9232/
+management:
+  server:
+    port: ${MANAGEMENT_SERVER_PORT}
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, info
+      base-path: ${MANAGEMENT_ENDPOINTS_WEB_BASE_PATH}
+    jmx:
+      exposure:
+        exclude: '*'
+  endpoint:
+    health:
+      enabled: true
+    info:
+      enabled: true
+    prometheus:
+      enabled: true


### PR DESCRIPTION
추가된 환경변수
- `MANAGEMENT_SERVER_PORT` 
  - 기존과 다른 포트를 사용하기 위해 설정
- `MANAGEMENT_ENDPOINTS_WEB_BASE_PATH`
  - spring actuator에 접근할 시 앞에 붙는 경로이다. 기본값은 `actuator`
  
### 배포 전 해야할 목록
- [x] 환경 변수 업로드

### 배포 이후

- [ ] 포트 보안 규칙 변경 후 제대로 접속 가능한지 확인

### See Also

https://techblog.woowahan.com/9232/